### PR TITLE
[WabiSab] Model for transaction state

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -287,14 +287,7 @@ namespace WalletWasabi.Tests.Helpers
 				Array.Empty<long>(),
 				amClient.Credentials.Valuable);
 
-			try
-			{
-				weight ??= script.EstimateOutputVsize() * 4;
-			}
-			catch (NotImplementedException)
-			{
-				weight = 100;
-			}
+			weight ??= script.EstimateOutputVsize() * 4;
 
 			var (realWeightCredentialRequest, _) = weClient.CreateRequest(
 				new[] { startingWeightCredentialAmount - (long)weight },

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -199,7 +199,11 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			{
 				var orresp = await arena.RegisterOutputAsync(orreq);
 			}
-			round.Alices.Add(WabiSabiFactory.CreateAlice(value: round.MinRegistrableAmount - Money.Satoshis(1)));
+
+			var extraAlice = WabiSabiFactory.CreateAlice(value: round.MinRegistrableAmount);
+			round.Alices.Add(extraAlice);
+			round.CoinjoinState = round.CoinjoinState.AssertConstruction().AddInput(extraAlice.Coins.First());
+
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.TransactionSigning, round.Phase);
 			Assert.Equal(3, round.Coinjoin.Inputs.Count);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -200,6 +200,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 				var orresp = await arena.RegisterOutputAsync(orreq);
 			}
 
+			// TODO the feerate will reduce this input's balance input to below the minimum output amount, allowing this test to pass, but this is arguably a bug
 			var extraAlice = WabiSabiFactory.CreateAlice(value: round.MinRegistrableAmount);
 			round.Alices.Add(extraAlice);
 			round.CoinjoinState = round.CoinjoinState.AssertConstruction().AddInput(extraAlice.Coins.First());

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -405,6 +405,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			var alice3 = WabiSabiFactory.CreateAlice();
 			alice3.ConfirmedConnetion = true;
 			round.Alices.Add(alice3);
+			round.CoinjoinState = round.CoinjoinState.AssertConstruction().AddInput(alice3.Coins.First());
 			await arena.TriggerAndWaitRoundAsync(TimeSpan.FromSeconds(21));
 			Assert.Equal(Phase.TransactionSigning, round.Phase);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/RegisterOutputTests.cs
@@ -55,9 +55,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		{
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			round.SetPhase(Phase.OutputRegistration);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			using Key key = new();
+
+			round.SetPhase(Phase.OutputRegistration);
 
 			var req = WabiSabiFactory.CreateOutputRegistrationRequest(round, key.PubKey.GetAddress(ScriptPubKeyType.Legacy, Network.Main).ScriptPubKey);
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
@@ -72,9 +73,10 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 		{
 			WabiSabiConfig cfg = new();
 			var round = WabiSabiFactory.CreateRound(cfg);
-			round.SetPhase(Phase.OutputRegistration);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 			using Key key = new();
+
+			round.SetPhase(Phase.OutputRegistration);
 
 			var sha256Bounty = Script.FromHex("aa20000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f87");
 			var req = WabiSabiFactory.CreateOutputRegistrationRequest(round, sha256Bounty);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PostRequests/SignTransactionTests.cs
@@ -26,18 +26,17 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			using Key key = new();
 			Alice alice = WabiSabiFactory.CreateAlice(key: key);
 			round.Alices.Add(alice);
-			var coinjoin = round.Coinjoin;
-			coinjoin.Inputs.Add(alice.Coins.First().Outpoint);
+			round.CoinjoinState = round.AddInput(alice.Coins.First()).Finalize();
 			round.SetPhase(Phase.TransactionSigning);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
-			var signedCoinJoin = coinjoin.Clone();
-			signedCoinJoin.Sign(key.GetBitcoinSecret(Network.Main), alice.Coins.First());
+			var aliceSignedCoinJoin = round.CoinjoinState.AssertSigning().CreateUnsignedTransaction();
+			aliceSignedCoinJoin.Sign(key.GetBitcoinSecret(Network.Main), alice.Coins.First());
 
-			var req = new TransactionSignaturesRequest(round.Id, new[] { new InputWitnessPair(0, signedCoinJoin.Inputs[0].WitScript) });
+			var req = new TransactionSignaturesRequest(round.Id, new[] { new InputWitnessPair(0, aliceSignedCoinJoin.Inputs[0].WitScript) });
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 			await handler.SignTransactionAsync(req);
-			Assert.True(round.Coinjoin.Inputs.First().HasWitScript());
+			Assert.True(round.CoinjoinState.AssertSigning().IsFullySigned);
 			await arena.StopAsync(CancellationToken.None);
 		}
 
@@ -85,17 +84,15 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PostRequests
 			Alice alice2 = WabiSabiFactory.CreateAlice(key: key2);
 			round.Alices.Add(alice1);
 			round.Alices.Add(alice2);
-			var coinjoin = round.Coinjoin;
-			coinjoin.Inputs.Add(alice1.Coins.First().Outpoint);
-			coinjoin.Inputs.Add(alice2.Coins.First().Outpoint);
+			round.CoinjoinState = round.CoinjoinState.AssertConstruction().AddInput(alice1.Coins.First()).AddInput(alice2.Coins.First()).Finalize();
 			round.SetPhase(Phase.TransactionSigning);
 			using Arena arena = await WabiSabiFactory.CreateAndStartArenaAsync(cfg, round);
 
 			// Submit the signature for the second alice to the first alice's input.
-			var signedCoinJoin = coinjoin.Clone();
-			signedCoinJoin.Sign(key2.GetBitcoinSecret(Network.Main), alice2.Coins.First());
+			var alice2signedCoinJoin = round.CoinjoinState.AssertSigning().CreateUnsignedTransaction();
+			alice2signedCoinJoin.Sign(key2.GetBitcoinSecret(Network.Main), alice2.Coins.First());
 
-			var req = new TransactionSignaturesRequest(round.Id, new[] { new InputWitnessPair(0, signedCoinJoin.Inputs[0].WitScript) });
+			var req = new TransactionSignaturesRequest(round.Id, new[] { new InputWitnessPair(0, alice2signedCoinJoin.Inputs[0].WitScript) });
 			await using ArenaRequestHandler handler = new(cfg, new Prison(), arena, new MockRpcClient());
 			var ex = await Assert.ThrowsAsync<WabiSabiProtocolException>(async () => await handler.SignTransactionAsync(req));
 			Assert.Equal(WabiSabiProtocolErrorCode.WrongCoinjoinSignature, ex.ErrorCode);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransaction.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransaction.cs
@@ -11,8 +11,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 {
 	public class MultipartyTransactionTests
 	{
-		static MoneyRange DefaultAllowedAmounts = new MoneyRange(Money.Zero, Money.Coins(1));
-		static Parameters DefaultParameters = new Parameters(FeeRate.Zero, DefaultAllowedAmounts, DefaultAllowedAmounts, Network.Main);
+		static MoneyRange DefaultAllowedAmounts = new (Money.Zero, Money.Coins(1));
+		static Parameters DefaultParameters = new (FeeRate.Zero, DefaultAllowedAmounts, DefaultAllowedAmounts, Network.Main);
 
 		[Fact]
 		public void TwoPartyNoFees()
@@ -100,9 +100,9 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			var duplicateOutputNoFee = withOutput.AddOutput(bob).Finalize();
 
 			var tx2 = duplicateOutputNoFee.CreateUnsignedTransaction();
-			Assert.Equal(1, tx2.Outputs.Count);
-			Assert.Contains(script, tx2.Outputs.Select(x => x.ScriptPubKey));
-			Assert.Equal(alice.Coins.First().Amount, tx2.Outputs[0].Value);
+			var output = Assert.Single(tx2.Outputs);
+			Assert.Equal(script, output.ScriptPubKey);
+			Assert.Equal(alice.Coins.First().Amount, output.Value);
 		}
 
 		[Fact]
@@ -197,7 +197,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
 			var signed = alice2Sig.CreateTransaction();
 			Assert.NotEqual(alice1Tx.ToString(), signed.ToString());
 			Assert.NotEqual(alice2Tx.ToString(), signed.ToString());
-			Assert.True(signed.Inputs.All(x => x.HasWitScript()));
+			Assert.All(signed.Inputs, x => Assert.True(x.HasWitScript()));
 
 			var coins = new[] { alice1.Coins.First(), alice2.Coins.First() };
 			Assert.True(signed.GetVirtualSize() * 4 < generousFeeTx.EstimatedWeight);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransaction.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransaction.cs
@@ -1,0 +1,273 @@
+using NBitcoin;
+using System.Collections.Immutable;
+using System.Linq;
+using WalletWasabi.WabiSabi.Backend.Models;
+using WalletWasabi.WabiSabi.Models;
+using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
+using WalletWasabi.Tests.Helpers;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.WabiSabi.Models
+{
+	public class MultipartyTransactionTests
+	{
+		static MoneyRange DefaultAllowedAmounts = new MoneyRange(Money.Zero, Money.Coins(1));
+		static Parameters DefaultParameters = new Parameters(FeeRate.Zero, DefaultAllowedAmounts, DefaultAllowedAmounts, Network.Main);
+
+		[Fact]
+		public void TwoPartyNoFees()
+		{
+			using Key key1 = new();
+			using Key key2 = new();
+
+			var alice1 = WabiSabiFactory.CreateAlice(key: key1);
+			var alice2 = WabiSabiFactory.CreateAlice(key: key2);
+
+			var state = new Construction(DefaultParameters);
+
+			Assert.Empty(state.Inputs);
+			Assert.Empty(state.Outputs);
+
+			var oneInput = state.AddInput(alice1.Coins.First());
+
+			Assert.Single(oneInput.Inputs);
+			Assert.Empty(oneInput.Outputs);
+
+			// Previous state should be unmodified
+			Assert.Empty(state.Inputs);
+			Assert.Empty(state.Outputs);
+
+			var differentInput = state.AddInput(alice2.Coins.First());
+
+			Assert.Single(differentInput.Inputs);
+			Assert.Empty(differentInput.Outputs);
+			Assert.NotEqual(oneInput.Inputs, differentInput.Inputs);
+			Assert.Equal(oneInput.Outputs, differentInput.Outputs);
+
+			var twoInputs = oneInput.AddInput(alice2.Coins.First());
+
+			Assert.Equal(2, twoInputs.Inputs.Count());
+			Assert.Empty(twoInputs.Outputs);
+
+			// address reuse bad
+			var bob1 = new TxOut(Money.Coins(1), alice1.Coins.First().ScriptPubKey);
+			var withOutput = twoInputs.AddOutput(bob1);
+
+			Assert.Equal(2, withOutput.Inputs.Count());
+			Assert.Single(withOutput.Outputs);
+
+			var bob2 = new TxOut(Money.Coins(1), alice2.Coins.First().ScriptPubKey);
+			var noFeeTx = withOutput.AddOutput(bob2).Finalize();
+			Assert.Equal(Money.Zero, noFeeTx.Balance);
+
+			var tx = noFeeTx.CreateUnsignedTransaction();
+			Assert.Equal(2, tx.Inputs.Count());
+			Assert.Equal(2, tx.Outputs.Count);
+			Assert.Contains(alice1.Coins.First().Outpoint, tx.Inputs.Select(x => x.PrevOut));
+			Assert.Contains(alice2.Coins.First().Outpoint, tx.Inputs.Select(x => x.PrevOut));
+			Assert.Contains(alice1.Coins.First().ScriptPubKey, tx.Outputs.Select(x => x.ScriptPubKey));
+			Assert.Contains(alice2.Coins.First().ScriptPubKey, tx.Outputs.Select(x => x.ScriptPubKey));
+
+			var alice1Tx = tx.Clone();
+			alice1Tx.Sign(key1.GetBitcoinSecret(Network.Main), alice1.Coins.First());
+
+			var alice1Sig = noFeeTx.AddWitness(0, alice1Tx.Inputs[0].WitScript);
+			Assert.False(alice1Sig.IsFullySigned);
+			Assert.Equal(alice1Tx.ToString(), alice1Sig.CreateTransaction().ToString());
+
+			var alice2Tx = tx.Clone();
+			alice2Tx.Sign(key2.GetBitcoinSecret(Network.Main), alice2.Coins.First());
+
+			var alice2Sig = alice1Sig.AddWitness(1, alice2Tx.Inputs[1].WitScript);
+			Assert.True(alice2Sig.IsFullySigned);
+
+			var signed = alice2Sig.CreateTransaction();
+			Assert.NotEqual(alice1Tx.ToString(), signed.ToString());
+			Assert.NotEqual(alice2Tx.ToString(), signed.ToString());
+			Assert.True(signed.Inputs.All(x => x.HasWitScript()));
+		}
+
+		[Fact]
+		public void AddWithOptimize()
+		{
+			var alice = WabiSabiFactory.CreateAlice();
+
+			var state = new Construction(DefaultParameters).AddInput(alice.Coins.First());
+
+			var script = BitcoinFactory.CreateScript();
+			var bob = new TxOut(alice.Coins.First().Amount/2, script);
+			var withOutput = state.AddOutput(bob);
+			var duplicateOutputNoFee = withOutput.AddOutput(bob).Finalize();
+
+			var tx2 = duplicateOutputNoFee.CreateUnsignedTransaction();
+			Assert.Equal(1, tx2.Outputs.Count);
+			Assert.Contains(script, tx2.Outputs.Select(x => x.ScriptPubKey));
+			Assert.Equal(alice.Coins.First().Amount, tx2.Outputs[0].Value);
+		}
+
+		[Fact]
+		public void WitnessValidation()
+		{
+			using Key key1 = new();
+			using Key key2 = new();
+
+			var alice1 = WabiSabiFactory.CreateAlice(key: key1);
+			var alice2 = WabiSabiFactory.CreateAlice(key: key2);
+
+			var state = new Construction(DefaultParameters).AddInput(alice1.Coins.First()).AddInput(alice2.Coins.First());
+
+			// address reuse bad
+			var bob1 = new TxOut(Money.Coins(1), alice1.Coins.First().ScriptPubKey);
+			var withOutput = state.AddOutput(bob1);
+
+			var bob2 = new TxOut(Money.Coins(1), alice2.Coins.First().ScriptPubKey);
+			var noFeeTx = withOutput.AddOutput(bob2).Finalize();
+
+			var tx = noFeeTx.CreateUnsignedTransaction();
+
+			var alice1Tx = tx.Clone();
+			alice1Tx.Sign(key1.GetBitcoinSecret(Network.Main), alice1.Coins.First());
+			var alice2Tx = tx.Clone();
+			alice2Tx.Sign(key2.GetBitcoinSecret(Network.Main), alice2.Coins.First());
+
+			// Only accept valid witnesses
+			Assert.Equal(WabiSabiProtocolErrorCode.WrongCoinjoinSignature, Assert.Throws<WabiSabiProtocolException>(() => noFeeTx.AddWitness(1, alice1Tx.Inputs[0].WitScript)).ErrorCode);
+			Assert.Equal(WabiSabiProtocolErrorCode.WrongCoinjoinSignature, Assert.Throws<WabiSabiProtocolException>(() => noFeeTx.AddWitness(1, alice1Tx.Inputs[1].WitScript)).ErrorCode);
+			Assert.Equal(WabiSabiProtocolErrorCode.WrongCoinjoinSignature, Assert.Throws<WabiSabiProtocolException>(() => noFeeTx.AddWitness(0, alice1Tx.Inputs[1].WitScript)).ErrorCode);
+			Assert.Equal(WabiSabiProtocolErrorCode.WrongCoinjoinSignature, Assert.Throws<WabiSabiProtocolException>(() => noFeeTx.AddWitness(0, alice2Tx.Inputs[0].WitScript)).ErrorCode);
+			Assert.Equal(WabiSabiProtocolErrorCode.WrongCoinjoinSignature, Assert.Throws<WabiSabiProtocolException>(() => noFeeTx.AddWitness(0, alice2Tx.Inputs[1].WitScript)).ErrorCode);
+			Assert.Equal(WabiSabiProtocolErrorCode.WrongCoinjoinSignature, Assert.Throws<WabiSabiProtocolException>(() => noFeeTx.AddWitness(1, alice2Tx.Inputs[0].WitScript)).ErrorCode);
+
+			// Add Alice 1's signature
+			var alice1Sig = noFeeTx.AddWitness(0, alice1Tx.Inputs[0].WitScript);
+			Assert.False(alice1Sig.IsFullySigned);
+
+			// Witness can only be accepted once per input
+			Assert.Equal(WabiSabiProtocolErrorCode.WitnessAlreadyProvided, Assert.Throws<WabiSabiProtocolException>(() => alice1Sig.AddWitness(0, alice1Tx.Inputs[0].WitScript)).ErrorCode);
+		}
+
+		[Fact]
+		public void FeeRateValidation()
+		{
+			var feeRate = new FeeRate(new Money(1000L));
+
+			using Key key1 = new();
+			using Key key2 = new();
+
+			var alice1 = WabiSabiFactory.CreateAlice(key: key1);
+			var alice2 = WabiSabiFactory.CreateAlice(key: key2);
+
+			var state = new Construction(DefaultParameters with { FeeRate = feeRate })
+				.AddInput(alice1.Coins.First())
+				.AddInput(alice2.Coins.First());
+
+			var bob1 = new TxOut(Money.Coins(1), alice1.Coins.First().ScriptPubKey);
+			var withOutput = state.AddOutput(bob1);
+
+			Assert.Equal(2, withOutput.Inputs.Count());
+			Assert.Single(withOutput.Outputs);
+
+			var bob2 = new TxOut(Money.Coins(1), alice2.Coins.First().ScriptPubKey);
+			Assert.Equal(WabiSabiProtocolErrorCode.InsufficientFees, Assert.Throws<WabiSabiProtocolException>(() => withOutput.AddOutput(bob2).Finalize()).ErrorCode);
+
+			bob2 = new TxOut(Money.Coins(0.9999m), alice2.Coins.First().ScriptPubKey);
+			var generousFeeTx = withOutput.AddOutput(bob2).Finalize();
+
+			var tx = generousFeeTx.CreateUnsignedTransaction();
+			Assert.Equal(2, tx.Inputs.Count);
+			Assert.Equal(2, tx.Outputs.Count);
+			Assert.Contains(alice1.Coins.First().Outpoint, tx.Inputs.Select(x => x.PrevOut));
+			Assert.Contains(alice2.Coins.First().Outpoint, tx.Inputs.Select(x => x.PrevOut));
+			Assert.Contains(alice1.Coins.First().ScriptPubKey, tx.Outputs.Select(x => x.ScriptPubKey));
+			Assert.Contains(alice2.Coins.First().ScriptPubKey, tx.Outputs.Select(x => x.ScriptPubKey));
+
+			var alice1Tx = tx.Clone();
+			alice1Tx.Sign(key1.GetBitcoinSecret(Network.Main), alice1.Coins.First());
+
+			var alice1Sig = generousFeeTx.AddWitness(0, alice1Tx.Inputs[0].WitScript);
+			Assert.False(alice1Sig.IsFullySigned);
+			Assert.Equal(alice1Tx.ToString(), alice1Sig.CreateTransaction().ToString());
+
+			var alice2Tx = tx.Clone();
+			alice2Tx.Sign(key2.GetBitcoinSecret(Network.Main), alice2.Coins.First());
+
+			var alice2Sig = alice1Sig.AddWitness(1, alice2Tx.Inputs[1].WitScript);
+			Assert.True(alice2Sig.IsFullySigned);
+
+			var signed = alice2Sig.CreateTransaction();
+			Assert.NotEqual(alice1Tx.ToString(), signed.ToString());
+			Assert.NotEqual(alice2Tx.ToString(), signed.ToString());
+			Assert.True(signed.Inputs.All(x => x.HasWitScript()));
+
+			var coins = new[] { alice1.Coins.First(), alice2.Coins.First() };
+			Assert.True(signed.GetVirtualSize() * 4 < generousFeeTx.EstimatedWeight);
+			Assert.True(feeRate <= signed.GetFeeRate(coins));
+			Assert.Equal(generousFeeTx.Balance, signed.GetFee(coins));
+		}
+
+		[Fact]
+		public void NoDuplicateInputs()
+		{
+			var alice = WabiSabiFactory.CreateAlice();
+			var state = new Construction(DefaultParameters).AddInput(alice.Coins.First());
+			Assert.Equal(WabiSabiProtocolErrorCode.NonUniqueInputs, Assert.Throws<WabiSabiProtocolException>(() => state.AddInput(alice.Coins.First())).ErrorCode);
+			Assert.Single(state.Inputs);
+		}
+
+		// TODO nonstandard input
+
+		[Fact]
+		public void OnlyAllowedInputTypes()
+		{
+			var legacyOnly = new Construction(DefaultParameters with { AllowedInputTypes = ImmutableSortedSet<ScriptType>.Empty.Add(ScriptType.P2PKH) });
+			var alice = WabiSabiFactory.CreateAlice();
+			Assert.Equal(WabiSabiProtocolErrorCode.ScriptNotAllowed, Assert.Throws<WabiSabiProtocolException>(() => legacyOnly.AddInput(alice.Coins.First())).ErrorCode);
+		}
+
+		[Fact]
+		public void InputAmountRanges()
+		{
+			var alice = WabiSabiFactory.CreateAlice();
+
+			var exact = new Construction(DefaultParameters with { AllowedInputAmounts = new MoneyRange(alice.Coins.First().Amount, alice.Coins.First().Amount) });
+			var above = new Construction(DefaultParameters with { AllowedInputAmounts = new MoneyRange(2 * alice.Coins.First().Amount, 3 * alice.Coins.First().Amount) });
+			var below = new Construction(DefaultParameters with { AllowedInputAmounts = new MoneyRange(alice.Coins.First().Amount - Money.Coins(0.001m), alice.Coins.First().Amount - Money.Coins(0.0001m)) });
+
+			Assert.Equal(WabiSabiProtocolErrorCode.NotEnoughFunds, Assert.Throws<WabiSabiProtocolException>(() => above.AddInput(alice.Coins.First())).ErrorCode);
+			Assert.Equal(WabiSabiProtocolErrorCode.TooMuchFunds, Assert.Throws<WabiSabiProtocolException>(() => below.AddInput(alice.Coins.First())).ErrorCode);
+
+			// Allowed range is inclusive:
+			exact.AddInput(alice.Coins.First());
+		}
+
+		[Fact]
+		public void NoNonStandardOutput()
+		{
+			var state = new Construction(DefaultParameters);
+			var sha256Bounty = new TxOut(Money.Coins(1), Script.FromHex("aa20000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f87"));
+			Assert.Equal(WabiSabiProtocolErrorCode.NonStandardOutput, Assert.Throws<WabiSabiProtocolException>(() => state.AddOutput(sha256Bounty)).ErrorCode);
+		}
+
+		[Fact]
+		public void OnlyAllowedOutputTypes()
+		{
+			var legacyOnly = new Construction(DefaultParameters with { AllowedOutputTypes = ImmutableSortedSet<ScriptType>.Empty.Add(ScriptType.P2PKH) });
+			var p2wpkh = BitcoinFactory.CreateScript();
+			Assert.Equal(WabiSabiProtocolErrorCode.ScriptNotAllowed, Assert.Throws<WabiSabiProtocolException>(() => legacyOnly.AddOutput(new TxOut(Money.Coins(1), p2wpkh))).ErrorCode);
+		}
+
+		[Fact]
+		public void OutputAmountRanges()
+		{
+			var costly = new Construction(DefaultParameters with { AllowedOutputAmounts = new MoneyRange(Money.Coins(7), Money.Coins(11)) });
+
+			var p2wpkh = BitcoinFactory.CreateScript();
+			Assert.Equal(WabiSabiProtocolErrorCode.NotEnoughFunds, Assert.Throws<WabiSabiProtocolException>(() => costly.AddOutput(new TxOut(Money.Coins(1), p2wpkh))).ErrorCode);
+			Assert.Equal(WabiSabiProtocolErrorCode.TooMuchFunds, Assert.Throws<WabiSabiProtocolException>(() => costly.AddOutput(new TxOut(Money.Coins(12), p2wpkh))).ErrorCode);
+
+			// Allowed range is inclusive:
+			costly.AddOutput(new TxOut(Money.Coins(7), p2wpkh));
+			costly.AddOutput(new TxOut(Money.Coins(11), p2wpkh));
+		}
+	}
+}

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -457,16 +457,7 @@ namespace NBitcoin
 		}
 
 		public static int EstimateOutputVsize(this Script script)
-		{
-			if (script.IsScriptType(ScriptType.P2WPKH))
-			{
-				return Constants.OutputSizeInBytes;
-			}
-			else
-			{
-				throw new NotImplementedException($"Weight estimation isn't implemented for provided script type.");
-			}
-		}
+			=> new TxOut(Money.Zero, script).ToBytes().Length;
 
 		public static int EstimateInputVsize(this Script script)
 		{

--- a/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
+++ b/WalletWasabi/WabiSabi/Backend/Models/WabiSabiProtocolErrorCode.cs
@@ -27,6 +27,10 @@ namespace WalletWasabi.WabiSabi.Backend.Models
 		IncorrectRequestedAmountCredentials,
 		WrongCoinjoinSignature,
 		AliceAlreadyRegistered,
-		NonStandardOutput
+		NonStandardInput,
+		NonStandardOutput,
+		WitnessAlreadyProvided,
+		InsufficientFees,
+		WeightLimitExceeded
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -53,6 +53,8 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 				{
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InputImmature);
 				}
+
+				// TODO remove (redundant with transaction model, needlessly restrictive)
 				if (!txOutResponse.TxOut.ScriptPubKey.IsScriptType(ScriptType.P2WPKH))
 				{
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed);

--- a/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
+++ b/WalletWasabi/WabiSabi/Backend/PostRequests/InputRegistrationHandler.cs
@@ -104,6 +104,7 @@ namespace WalletWasabi.WabiSabi.Backend.PostRequests
 				var coin = coinRoundSignaturePair.Key;
 				var signature = coinRoundSignaturePair.Value;
 
+				// TODO should ownership proof verification be part of the MultipartyTransaction model?
 				var coinJoinInputCommitmentData = new CoinJoinInputCommitmentData("CoinJoinCoordinatorIdentifier", round.Hash);
 				if (!OwnershipProof.VerifyCoinJoinInputProof(signature, coin.TxOut.ScriptPubKey, coinJoinInputCommitmentData))
 				{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -121,32 +121,21 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 				var diff = aliceSum - bobSum;
 				if (diff == 0 || round.OutputRegistrationStart + round.OutputRegistrationTimeout < DateTimeOffset.UtcNow)
 				{
-					// Build a coinjoin:
-					var coinjoin = round.Coinjoin;
+					var coinjoin = round.CoinjoinState.AssertConstruction();
 
-					// Add inputs:
-					var spentCoins = round.Alices.SelectMany(x => x.Coins).ToArray();
-					foreach (var input in spentCoins.Select(x => x.Outpoint))
-					{
-						coinjoin.Inputs.Add(input);
-					}
-					round.LogInfo($"{coinjoin.Inputs.Count} inputs were added.");
-
-					// Add outputs:
-					foreach (var bob in round.Bobs)
-					{
-						coinjoin.Outputs.AddWithOptimize(bob.CalculateOutputAmount(round.FeeRate), bob.Script);
-					}
-					round.LogInfo($"{round.Bobs.Count} outputs were added.");
+					round.LogInfo($"{coinjoin.Inputs.Count()} inputs were added.");
+					round.LogInfo($"{coinjoin.Outputs.Count()} outputs were added.");
 
 					// If timeout we must fill up the outputs to build a reasonable transaction.
 					// This won't be signed by the alice who failed to provide output, so we know who to ban.
-					if (diff > round.MinRegistrableAmount)
+					if (diff > coinjoin.Parameters.AllowedOutputAmounts.Min)
 					{
 						var diffMoney = Money.Satoshis(diff);
-						coinjoin.Outputs.AddWithOptimize(diffMoney, Config.BlameScript);
+						coinjoin = coinjoin.AddOutput(new TxOut(diffMoney, Config.BlameScript));
 						round.LogInfo("Filled up the outputs to build a reasonable transaction because some alice failed to provide its output.");
 					}
+
+					round.CoinjoinState = coinjoin.Finalize();
 
 					round.SetPhase(Phase.TransactionSigning);
 				}
@@ -157,13 +146,14 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 		{
 			foreach (var round in Rounds.Values.Where(x => x.Phase == Phase.TransactionSigning).ToArray())
 			{
-				var coinjoin = round.Coinjoin;
-				var isFullySigned = coinjoin.Inputs.All(x => x.HasWitScript());
+				var state = round.CoinjoinState.AssertSigning();
 
 				try
 				{
-					if (isFullySigned)
+					if (state.IsFullySigned)
 					{
+						var coinjoin = state.CreateTransaction();
+
 						// Logging.
 						round.LogInfo("Trying to broadcast coinjoin.");
 						Coin[]? spentCoins = round.Alices.SelectMany(x => x.Coins).ToArray();
@@ -202,10 +192,13 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 		private async Task FailTransactionSigningPhaseAsync(Round round)
 		{
-			var unsignedCoins = round.Coinjoin.Inputs.Where(x => !x.HasWitScript()).Select(x => x.PrevOut);
+			var state = round.CoinjoinState.AssertSigning();
+
+			var unsignedPrevouts = state.UnsignedInputs.ToHashSet();
+
 			var alicesWhoDidntSign = round.Alices
-				.SelectMany(alice => alice.Coins, (alice, coin) => (Alice: alice, coin.Outpoint))
-				.Where(x => unsignedCoins.Contains(x.Outpoint))
+				.SelectMany(alice => alice.Coins, (alice, coin) => (Alice: alice, Coin: coin))
+				.Where(x => unsignedPrevouts.Contains(x.Coin))
 				.Select(x => x.Alice)
 				.ToHashSet();
 
@@ -329,9 +322,21 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 				}
 				else if (round.Phase == Phase.ConnectionConfirmation)
 				{
+
+					var state = round.CoinjoinState.AssertConstruction();
+
+					foreach (var coin in alice.Coins)
+					{
+						// Ensure the input can be added to the CoinJoin
+						state = state.AddInput(coin);
+					}
+
 					var commitAmountRealCredentialResponse = round.AmountCredentialIssuer.PrepareRequest(realAmountCredentialRequests);
 					var commitWeightRealCredentialResponse = round.WeightCredentialIssuer.PrepareRequest(realWeightCredentialRequests);
+
+					// update state
 					alice.ConfirmedConnetion = true;
+					round.CoinjoinState = state;
 
 					return new(
 						commitAmountZeroCredentialResponse(),
@@ -357,27 +362,9 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 				var credentialAmount = -request.AmountCredentialRequests.Delta;
 
-				if (!StandardScripts.IsStandardScriptPubKey(request.Script))
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonStandardOutput, $"Round ({request.RoundId}): Non standard output.");
-				}
-
-				if (!request.Script.IsScriptType(ScriptType.P2WPKH))
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed, $"Round ({request.RoundId}): Script not allowed.");
-				}
-
 				Bob bob = new(request.Script, credentialAmount);
 
 				var outputValue = bob.CalculateOutputAmount(round.FeeRate);
-				if (outputValue < round.MinRegistrableAmount)
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds, $"Round ({request.RoundId}): Not enough funds.");
-				}
-				if (outputValue > round.MaxRegistrableAmount)
-				{
-					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds, $"Round ({request.RoundId}): Too much funds.");
-				}
 
 				var weightCredentialRequests = request.WeightCredentialRequests;
 				if (-weightCredentialRequests.Delta != bob.CalculateWeight())
@@ -390,11 +377,18 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase, $"Round ({request.RoundId}): Wrong phase ({round.Phase}).");
 				}
 
+				// Update the current round state with the additional output to ensure it's valid.
+				var newState = round.AddOutput(new TxOut(outputValue, bob.Script));
+
+				// Verify the credential requests and prepare their responses.
 				var commitAmountCredentialResponse = round.AmountCredentialIssuer.PrepareRequest(request.AmountCredentialRequests);
 				var commitWeightCredentialResponse = round.WeightCredentialIssuer.PrepareRequest(weightCredentialRequests);
 
+				// Update round state.
 				round.Bobs.Add(bob);
+				round.CoinjoinState = newState;
 
+				// Issue credentials and mark presented credentials as used.
 				return new(
 					commitAmountCredentialResponse(),
 					commitWeightCredentialResponse());
@@ -414,39 +408,15 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 				{
 					throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongPhase, $"Round ({request.RoundId}): Wrong phase ({round.Phase}).");
 				}
+
+				var state = round.CoinjoinState.AssertSigning();
 				foreach (var inputWitnessPair in request.InputWitnessPairs)
 				{
-					var index = (int)inputWitnessPair.InputIndex;
-					var witness = inputWitnessPair.Witness;
-
-					// If input is already signed, don't bother.
-					if (round.Coinjoin.Inputs[index].HasWitScript())
-					{
-						continue;
-					}
-
-					// Verify witness.
-					// 1. Copy UnsignedCoinJoin.
-					Transaction cjCopy = Transaction.Parse(round.Coinjoin.ToHex(), Network);
-
-					// 2. Sign the copy.
-					cjCopy.Inputs[index].WitScript = witness;
-
-					// 3. Convert the current input to IndexedTxIn.
-					IndexedTxIn currentIndexedInput = cjCopy.Inputs.AsIndexedInputs().Skip(index).First();
-
-					// 4. Find the corresponding registered input.
-					Coin registeredCoin = round.Alices.SelectMany(x => x.Coins).Single(x => x.Outpoint == cjCopy.Inputs[index].PrevOut);
-
-					// 5. Verify if currentIndexedInput is correctly signed, if not, return the specific error.
-					if (!currentIndexedInput.VerifyScript(registeredCoin, out ScriptError error))
-					{
-						throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongCoinjoinSignature, $"Round ({request.RoundId}): Wrong CoinJoin signature.");
-					}
-
-					// Finally add it to our CJ.
-					round.Coinjoin.Inputs[index].WitScript = witness;
+					state = state.AddWitness((int)inputWitnessPair.InputIndex, inputWitnessPair.Witness);
 				}
+
+				// at this point all of the witnesses have been verified and the state can be updated
+				round.CoinjoinState = state;
 			}
 		}
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -139,13 +139,6 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 					}
 					round.LogInfo($"{round.Bobs.Count} outputs were added.");
 
-					// Shuffle & sort:
-					// This is basically just decoration.
-					coinjoin.Inputs.Shuffle();
-					coinjoin.Outputs.Shuffle();
-					coinjoin.Inputs.SortByAmount(spentCoins);
-					coinjoin.Outputs.SortByAmount();
-
 					// If timeout we must fill up the outputs to build a reasonable transaction.
 					// This won't be signed by the alice who failed to provide output, so we know who to ban.
 					if (diff > round.MinRegistrableAmount)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -28,6 +28,10 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 			AmountCredentialIssuerParameters = AmountCredentialIssuer.CredentialIssuerSecretKey.ComputeCredentialIssuerParameters();
 			WeightCredentialIssuerParameters = WeightCredentialIssuer.CredentialIssuerSecretKey.ComputeCredentialIssuerParameters();
 
+			// TODO allowed input and output amounts should differ by at least
+			// the cost of a single p2wpkh input and a single p2wpkh output,
+			// otherwise some registrable input balances can result in no output
+			// registrations.
 			var allowedAmounts = new MoneyRange(roundParameters.MinRegistrableAmount, RoundParameters.MaxRegistrableAmount);
 			var txParams = new MP.Parameters(roundParameters.FeeRate, allowedAmounts, allowedAmounts, roundParameters.Network);
 			CoinjoinState = new MP.Construction(txParams);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -41,6 +41,7 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds
 
 		public MP.State CoinjoinState { get; set; }
 
+		// TODO remove
 		public Transaction Coinjoin { get => CoinjoinState.AssertSigning().CreateTransaction(); }
 
 		public uint256 Hash { get; }

--- a/WalletWasabi/WabiSabi/Models/MoneyRange.cs
+++ b/WalletWasabi/WabiSabi/Models/MoneyRange.cs
@@ -1,0 +1,6 @@
+using NBitcoin;
+
+namespace WalletWasabi.WabiSabi.Models
+{
+	public record MoneyRange(Money Min, Money Max);
+}

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/Construction.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/Construction.cs
@@ -1,0 +1,97 @@
+using NBitcoin;
+using System.Collections.Immutable;
+using System.Linq;
+using WalletWasabi.Crypto;
+using WalletWasabi.WabiSabi.Backend.Models;
+
+namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
+{
+	// This class represents actions of the BIP 370 creator and constructor roles
+	public record Construction(Parameters Parameters) : State
+	{
+		public ImmutableList<Coin> Inputs { get; init; } = ImmutableList<Coin>.Empty;
+		public ImmutableList<TxOut> Outputs { get; init; } = ImmutableList<TxOut>.Empty;
+
+		public FeeRate EffectiveFeeRate { get => new FeeRate(Balance, EstimatedWeight/4); }
+
+		public Money Balance { get => Inputs.Select(x => x.Amount).Sum() - Outputs.Select(x => x.Value).Sum(); }
+
+		public int EstimatedWeight { get => Parameters.SharedOverhead + EstimatedInputsWeight + OutputsWeight; }
+		public int EstimatedInputsWeight { get => Inputs.Select(x => 4 * x.TxOut.ScriptPubKey.EstimateInputVsize()).Sum(); } // FIXME is this conservative? Add EstimateWeight and Weight attributes to NBitcoinExtensions
+		public int OutputsWeight { get => Outputs.Select(x => 4 * x.ScriptPubKey.EstimateOutputVsize()).Sum(); }
+
+		// TODO ownership proofs and spend status also in scope
+		public Construction AddInput(Coin coin)
+		{
+			var prevout = coin.TxOut;
+
+			if (prevout.Value < Parameters.AllowedInputAmounts.Min)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds);
+			}
+			if (prevout.Value > Parameters.AllowedInputAmounts.Max)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds);
+			}
+
+			if (!StandardScripts.IsStandardScriptPubKey(prevout.ScriptPubKey))
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonStandardInput);
+			}
+
+			if (!Parameters.AllowedInputTypes.Any(x => prevout.ScriptPubKey.IsScriptType(x)))
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed);
+			}
+
+			if (Inputs.Any(x => x.Outpoint == coin.Outpoint))
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonUniqueInputs);
+			}
+
+			return this with { Inputs = Inputs.Add(coin) };
+		}
+
+		public Construction AddOutput(TxOut output)
+		{
+			if (!StandardScripts.IsStandardScriptPubKey(output.ScriptPubKey))
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonStandardOutput);
+			}
+
+			if (!Parameters.AllowedOutputTypes.Any(x => output.ScriptPubKey.IsScriptType(x)))
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed);
+			}
+
+			if (output.Value < Parameters.AllowedOutputAmounts.Min)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NotEnoughFunds);
+			}
+
+			if (output.Value > Parameters.AllowedOutputAmounts.Max)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.TooMuchFunds);
+			}
+
+			return this with { Outputs = Outputs.Add(output) };
+		}
+
+		public Signing Finalize()
+		{
+			var weight = EstimatedWeight;
+
+			if (weight > Parameters.MaxWeight)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WeightLimitExceeded);
+			}
+
+			if (EffectiveFeeRate < Parameters.FeeRate)
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.InsufficientFees);
+			}
+
+			return new Signing(Parameters, Inputs.ToImmutableArray(), Outputs.ToImmutableArray());
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/Parameters.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/Parameters.cs
@@ -1,0 +1,26 @@
+using NBitcoin;
+using System.Collections.Immutable;
+
+namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
+{
+	// This represents parameters all clients must agree on to produce a valid &
+	// standard transaction subject to constraints.
+	public record Parameters(FeeRate FeeRate, MoneyRange AllowedInputAmounts, MoneyRange AllowedOutputAmounts, Network Network)
+	{
+		public static int SharedOverhead = 4*(4 + 4 + 3 + 3) + 1 + 1; // version, locktime, two 3 byte varints are non-witness data, marker and flags are witness data
+
+		public int MaxWeight { get; init; } = 400000; // ensure less than 400000?
+
+		public static ImmutableSortedSet<ScriptType> OnlyP2WPKH = ImmutableSortedSet<ScriptType>.Empty.Add(ScriptType.P2WPKH);
+
+		public ImmutableSortedSet<ScriptType> AllowedInputTypes { get; init; } = OnlyP2WPKH;
+		public ImmutableSortedSet<ScriptType> AllowedOutputTypes { get; init; } = OnlyP2WPKH;
+
+		public Transaction CreateTransaction()
+			// implied:
+			// segwit transaction
+			// version = 1
+			// nLocktime = 0
+			=> Transaction.Create(Network);
+	}
+}

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/Signing.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/Signing.cs
@@ -1,0 +1,88 @@
+using NBitcoin;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using WalletWasabi.WabiSabi.Backend.Models;
+
+namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
+{
+	public record Signing(Parameters Parameters, ImmutableArray<Coin> Inputs, ImmutableArray<TxOut> Outputs) : State
+	{
+		public ImmutableDictionary<int, WitScript> Witnesses { get; init; } = ImmutableDictionary<int, WitScript>.Empty;
+
+		public bool IsFullySigned { get => Witnesses.Count() == Inputs.Length; }
+
+		public IEnumerable<Coin> UnsignedInputs { get => Enumerable.Range(0, Inputs.Length).Where(i => !IsInputSigned(i)).Select(i => Inputs[i]); }
+
+		public bool IsInputSigned(int index)
+			=> Witnesses.ContainsKey(index);
+
+		public FeeRate EffectiveFeeRate { get => new FeeRate(Balance, EstimatedWeight/4); }
+
+		public Money Balance { get => Inputs.Select(x => x.Amount).Sum() - Outputs.Select(x => x.Value).Sum(); }
+
+		public int EstimatedWeight { get => Parameters.SharedOverhead + EstimatedInputsWeight + OutputsWeight; }
+		public int EstimatedInputsWeight { get => 4 * Inputs.Select(x => x.TxOut.ScriptPubKey.EstimateInputVsize()).Sum(); } // FIXME is this conservative? Add EstimateWeight and Weight attributes to NBitcoinExtensions
+		public int OutputsWeight { get => 4 * Outputs.Select(x => x.ScriptPubKey.EstimateOutputVsize()).Sum(); }
+
+		public Signing AddWitness(int index, WitScript witness)
+		{
+			if (IsInputSigned(index))
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WitnessAlreadyProvided);
+			}
+
+			// Verify witness.
+			// 1. Copy UnsignedCoinJoin.
+			Transaction cjCopy = CreateUnsignedTransaction();
+
+			// 2. Sign the copy.
+			cjCopy.Inputs[index].WitScript = witness;
+
+			// 3. Convert the current input to IndexedTxIn.
+			IndexedTxIn currentIndexedInput = cjCopy.Inputs.AsIndexedInputs().Skip(index).First();
+
+			// 4. Find the corresponding registered input.
+			Coin registeredCoin = Inputs[index];
+
+			// 5. Verify if currentIndexedInput is correctly signed, if not, return the specific error.
+			if (!currentIndexedInput.VerifyScript(registeredCoin, out ScriptError error))
+			{
+				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.WrongCoinjoinSignature); // TODO keep script error
+			}
+
+			return this with { Witnesses = Witnesses.Add(index, witness) };
+		}
+
+		public Transaction CreateUnsignedTransaction()
+		{
+			var tx = Parameters.CreateTransaction();
+
+			foreach (var coin in Inputs)
+			{
+				// implied:
+				// nSequence = FINAL
+				tx.Inputs.Add(coin.Outpoint);
+			}
+
+			foreach (var txout in Outputs)
+			{
+				tx.Outputs.AddWithOptimize(txout.Value, txout.ScriptPubKey);
+			}
+
+			return tx;
+		}
+
+		public Transaction CreateTransaction()
+		{
+			var tx = CreateUnsignedTransaction();
+
+			foreach (var (index, witness) in Witnesses)
+			{
+				tx.Inputs[index].WitScript = witness;
+			}
+
+			return tx;
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/State.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/State.cs
@@ -1,0 +1,7 @@
+namespace WalletWasabi.WabiSabi.Models.MultipartyTransaction
+{
+	public abstract record State {
+		public Construction AssertConstruction() => (Construction)this;
+		public Signing AssertSigning() => (Signing)this;
+	}
+}


### PR DESCRIPTION
This is a work in progress and will be rebased

- `Round` transaction state is defined by a mutable property containing immutable state models.
- Model updates can be calculated before committing to the round state (by updating the property), enabling two phase (prepare & commit) validation in parallel with the credentials.
- Model objects occupy two states:
  - Construction - inputs and outputs can be appended
  - Signing - valid witnesses can be added

Depends on #5504

TODO:

- [ ] enforcing balance and feerate in `Finalize` breaks some existing `Arena` tests
- [ ] move ownership proof verification from `Arena` to `Construction` state?
- [ ] tests for non-standard inputs
  - [ ] find a well known, spent non-standard output?
  - [ ] `AddInput`
  - [ ] input registration
- [ ] Don't allow useless inputs (possible when minimum input & output amounts are the same)
- [ ] clean up error codes
  - [ ] input vs. output errors - some related errors share a code, some have distinct codes
  - [ ] some names are confusing
- [ ] remove `Round.Coinjoin` computed property
- [ ] remove script restriction from `InputRegistrationHandler`